### PR TITLE
Add header atomic.h to  quantum_task.h

### DIFF
--- a/quantum/quantum_task.h
+++ b/quantum/quantum_task.h
@@ -27,6 +27,7 @@
 #include <memory>
 #include <list>
 #include <utility>
+#include <atomic>
 
 namespace Bloomberg {
 namespace quantum {


### PR DESCRIPTION
Add header atomic.h for c++20 build.  